### PR TITLE
getTemperatureSoll() should use type "gethkrtsoll" instead of "gethkrkomfort"

### DIFF
--- a/src/FritzboxAHA.php
+++ b/src/FritzboxAHA.php
@@ -231,7 +231,7 @@ class FritzboxAHA
      */
     public function getTemperatureSoll($ain)
     {
-        return $this->getTemperatureHkr($ain, "gethkrkomfort");
+        return $this->getTemperatureHkr($ain, "gethkrtsoll");
     }
 
     /**


### PR DESCRIPTION
getTemperatureSoll() should use type "gethkrtsoll" instead of "gethkrkomfort"

## Description

getTemperatureSoll() should use type "gethkrtsoll" instead of "gethkrkomfort"

## Motivation and context

## How has this been tested?

## Screenshots (if appropriate)

## Types of changes

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x ] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
